### PR TITLE
Add self-reference to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alto-plugin-help",
   "description": "help for alto-clif",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "oclif-version": "3.0.1",
   "author": "柏大衛",
   "oclif-author": "Jeff Dickey @jdxcode",
@@ -18,6 +18,7 @@
     "wrap-ansi": "^4.0.0"
   },
   "devDependencies": {
+    "alto-plugin-help": "^0",
     "@oclif/dev-cli": "^1.21.0",
     "@oclif/errors": "^1.2.2",
     "@oclif/plugin-legacy": "^1.1.3",

--- a/src/util.ts
+++ b/src/util.ts
@@ -63,7 +63,7 @@ function extractClass(exported: any): HelpBaseDerived {
   return exported && exported.default ? exported.default : exported
 }
 
-export function getHelpClass(config: IConfig, defaultClass = '@oclif/plugin-help'): HelpBaseDerived {
+export function getHelpClass(config: IConfig, defaultClass = 'alto-plugin-help'): HelpBaseDerived {
   const pjson = config.pjson
   const configuredClass = pjson && pjson.oclif &&  pjson.oclif.helpClass
 

--- a/test/commands/help.test.ts
+++ b/test/commands/help.test.ts
@@ -21,10 +21,10 @@ EXAMPLE
   $ oclif plugins
 
 COMMANDS
-  plugins:install    installs a plugin into the CLI
-  plugins:link       links a plugin into the CLI for development
-  plugins:uninstall  removes a plugin from the CLI
-  plugins:update     update installed plugins
+  plugins install    installs a plugin into the CLI
+  plugins link       links a plugin into the CLI for development
+  plugins uninstall  removes a plugin from the CLI
+  plugins update     update installed plugins
 
 `)
   })
@@ -59,6 +59,9 @@ VERSION
 
 USAGE
   $ oclif [COMMAND]
+
+TOPICS
+  plugins  list installed plugins
 
 COMMANDS
   help     display help for oclif

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -16,7 +16,7 @@ describe('util', () => {
     test
     .it('defaults to the class exported', () => {
       // eslint-disable-next-line node/no-extraneous-require
-      const defaultHelpClass = require('@oclif/plugin-help').default
+      const defaultHelpClass = require('alto-plugin-help').default
       delete config.pjson.oclif.helpClass
 
       expect(defaultHelpClass).not.be.undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,6 +440,21 @@ alto-command@^0:
     debug "^4.1.1"
     semver "^5.6.0"
 
+alto-plugin-help@^0:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/alto-plugin-help/-/alto-plugin-help-0.9.2.tgz#3355eda70727470e6e2dc47acacc2cf4f6c87eb1"
+  integrity sha512-teECAgAfi+P8/1XJf8g+7O40NPi4ZcnmBBrk8E5csvkrnX1ME8N2juczgRuHpWDGcabjpwNCm3SeP3LUHwFg6w==
+  dependencies:
+    "@oclif/config" "^1.15.1"
+    alto-command "^0"
+    chalk "^2.4.1"
+    indent-string "^4.0.0"
+    lodash.template "^4.4.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
+    widest-line "^2.0.1"
+    wrap-ansi "^4.0.0"
+
 ansi-escapes@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"


### PR DESCRIPTION
Interestingly, turns out @oclif/plugin-help needs to have access to itself in order for its tests to work. The package evidently depends on another package installing @oclif/plugin-help and then uses that. Fragile, but it works.

This PR makes that dependency more explicit, and modifies the hard-coded references to @oclif/plugin-help in the code to use alto-plugin-help instead.